### PR TITLE
Change from queue:work to queue:listen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ ENV QUEUE_CONNECTION=redis
 ENV QUEUE_NAME=default
 
 RUN apt-get update -yqq && apt-get install -yyqq \
+apt-transport-https \
+ca-certificates \
+wget
+
+RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+RUN sh -c 'echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list'
+
+RUN apt-get update -yqq && apt-get install -yyqq \
 git \
 openssh-client \
 php-imagick \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,16 @@ RUN apt-get update -yqq && apt-get install -yyqq \
 git \
 openssh-client \
 php-imagick \
-php7.0-fpm \
-php7.0-bcmath \
-php7.0-curl \
-php7.0-fpm \
-php7.0-gd \
-php7.0-mbstring \
-php7.0-mysql \
-php7.0-xml \
-php7.0-zip \
-php7.0-xdebug \
+php7.1-fpm \
+php7.1-bcmath \
+php7.1-curl \
+php7.1-fpm \
+php7.1-gd \
+php7.1-mbstring \
+php7.1-mysql \
+php7.1-xml \
+php7.1-zip \
+php7.1-xdebug \
 supervisor
 
 # Download trusted certs 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -11,7 +11,7 @@ autostart=true
 autorestart=true
 numprocs=1
 stdout_events_enabled=1
-command=php artisan queue:work --sleep=3 --tries=3 --daemon
+command=php artisan queue:listen --sleep=3 --tries=3
 
 [program:web]
 process_name=%(program_name)s_%(process_num)02d


### PR DESCRIPTION
Buy changing from queue:work to queue:listen we dont have to restart the container everytime we change the source code because queue:listen restarts the framework on each job

https://stackoverflow.com/questions/26048698/what-is-the-difference-between-queuework-daemon-and-queuelisten